### PR TITLE
Agregando configuracion de la BD MySQL en archivo de properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/bedu?serverTimezone=UTC
+spring.datasource.username=<root>
+spring.datasource.password=<password>
 
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type=TRACE
+
+spring.devtools.restart.enabled=false


### PR DESCRIPTION
Agregue la configuracion de JPA e Hibernate en el archivo application.properties para que todos podamos configurar de manera local nuestra conexion con nuestro usuario y password. La BD la llame "bedu".